### PR TITLE
Update tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-dependencies
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: |
+          pnpm config set fetch-retries 5
+          pnpm config set fetch-retry-factor 2
+          pnpm install
 
   build:
     name: Run build
@@ -16,7 +28,7 @@ jobs:
     needs: [install]
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-dependencies
+
       - run: pnpm build
 
   tests:
@@ -24,10 +36,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/install-dependencies
-    - run: anvil --fork-url https://mainnet.infura.io/v3/<INFURA_PROJECT_ID> &
-    - run: pnpm test
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-dependencies
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Start Anvil in background
+        run: anvil --fork-url https://nodes.sequence.app/arbitrum &
+      - run: pnpm test
 
   # NOTE: if you'd like to see example of how to run
   # tests per package in parallel, see 'v2' branch


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions tests workflow to use official Node.js setup, enable pnpm caching and retries, streamline build job, and integrate Foundry/Anvil for on-chain testing

CI:
- Replace custom install-dependencies step with actions/setup-node@v4, actions/cache@v4, and pnpm install with retry settings
- Remove the install-dependencies action from the build job
- Install Foundry nightly and launch an Arbitrum Anvil fork before running pnpm tests