### PR TITLE
Update publish-dists.yml

### DIFF
--- a/.github/workflows/publish-dists.yml
+++ b/.github/workflows/publish-dists.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -88,6 +90,9 @@ jobs:
           
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/publish-dists.yml
+++ b/.github/workflows/publish-dists.yml
@@ -99,7 +99,10 @@ jobs:
 
       - name: Validate commit messages
         run: |
-          git log -1 --pretty=%B | grep -E '^(feat|fix|docs|chore|test|refactor): .+' || exit 1
+          commit_range="${{ github.event.before }}..HEAD"
+          git log $commit_range --pretty=format:%s | while read -r msg; do
+            echo "$msg" | grep -E '^(feat|fix|docs|chore|test|refactor): .+' || { echo "Invalid commit message: $msg"; exit 1; }
+          done
 
       - name: Validate file paths
         run: |

--- a/.github/workflows/publish-dists.yml
+++ b/.github/workflows/publish-dists.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Validate file paths
         run: |
-          invalid_files=$(git diff --name-only HEAD~1 | grep -vE '^src|test|config/')
+          invalid_files=$(git diff --name-only HEAD~1 | grep -vE '^(src/|test/|config/)')
           if [ -n "$invalid_files" ]; then
             echo "Invalid file paths: $invalid_files"
             exit 1

--- a/.github/workflows/publish-dists.yml
+++ b/.github/workflows/publish-dists.yml
@@ -85,3 +85,21 @@ jobs:
 
             cd -
           done
+          
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Validate commit messages
+        run: |
+          git log -1 --pretty=%B | grep -E '^(feat|fix|docs|chore|test|refactor): .+' || exit 1
+
+      - name: Validate file paths
+        run: |
+          invalid_files=$(git diff --name-only HEAD~1 | grep -vE '^src|test|config/')
+          if [ -n "$invalid_files" ]; then
+            echo "Invalid file paths: $invalid_files"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary by Sourcery

Add a new validation job to the publish-dists GitHub Actions workflow to enforce commit message and file path standards.

CI:
- Introduce a `validate` job running on Ubuntu to verify commit messages follow conventional commit prefixes.
- Check changed file paths to allow only updates under `src`, `test`, or `config` directories.