### PR TITLE
Update tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,12 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install
-      # Remove: working-directory: ./app
+      working-directory: ./correct-path-to-package-json
 
     - name: Start local blockchain node
-      run: npx hardhat node &
-      # Or use npx ganache-cli --port 8545 &
+      run: # Fork latest mainnet state
+          anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
+          # Or use npx ganache-cli --port 8545 &
 
     - name: Wait for node
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Update the tests GitHub Actions workflow to fix the dependency path and switch the local blockchain startup to an Anvil mainnet fork

CI:
- Use the correct working-directory for installing dependencies
- Replace Hardhat node startup with Anvil mainnet fork for local blockchain tests
- Preserve the Ganache CLI fallback option