### PR TITLE
Update tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       # ... other steps ...
     - name: Install pnpm
-      run: npm install -g pnpm
+      run: npm install -g corepack & corepack enable &  corepack install
 
     - name: Install dependencies
       run: pnpm install
@@ -16,7 +16,7 @@ jobs:
     - name: Start local blockchain node
       run: # Fork latest mainnet state
           anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
-          # Or use npx ganache-cli --port 8545 &
+          # https://github.com/foundry-rs/foundry
 
     - name: Wait for node
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions tests workflow to install pnpm via Corepack and update the blockchain node setup comment to reference Foundry

CI:
- Use Corepack to install pnpm instead of installing pnpm directly
- Replace the Ganache CLI comment with a reference to the Foundry repository for the local blockchain node