### PR TITLE
Update GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
-      - run: pnpm install --no-frozen-lockfile
 
   build:
     name: Run build
@@ -24,17 +23,16 @@ jobs:
   tests:
     name: Run all tests
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [install]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v1.5.0
+          version: nightly
       - name: Start Anvil in background
         run: anvil --fork-url https://nodes.sequence.app/arbitrum &
-      - run: pnpm build
       - run: pnpm test
 
   # NOTE: if you'd like to see example of how to run


### PR DESCRIPTION
## Summary by Sourcery

Adjust the tests GitHub Actions workflow to streamline dependency installation and test execution configuration.

CI:
- Remove redundant pnpm install step from the install job in the tests workflow.
- Change the tests job dependency from the build job to the install job to align with the desired execution order.
- Update the Foundry toolchain used in tests to track the nightly version.
- Remove the explicit pnpm build step from the tests job so it only runs the test suite.