### PR TITLE
Remove permissions from pnpm-format-label workflow

### DIFF
--- a/.github/workflows/on_pr_pnpm-format-label.yml
+++ b/.github/workflows/on_pr_pnpm-format-label.yml
@@ -1,9 +1,5 @@
 name: pnpm-format-label
 
-permissions:
-  contents: read
-  issues: write
-
 on:
   pull_request:
     types: [labeled]


### PR DESCRIPTION
Removed permissions section from the workflow.

## Summary by Sourcery

CI:
- Remove the contents and issues permissions block from the pnpm-format-label workflow, relying on default GitHub Actions permissions instead.