### PR TITLE
Add workflow to publish package distributions

### DIFF
--- a/.github/workflows/Publish-Dists.yml
+++ b/.github/workflows/Publish-Dists.yml
@@ -76,7 +76,11 @@ jobs:
                 }
               };
 
-              rewrite(pkg.dependencies);
+              ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'].forEach((field) => {
+                if (pkg[field]) {
+                  rewrite(pkg[field]);
+                }
+              });
               fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
             '
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a Publish Dists workflow that builds packages, rewrites workspace dependencies for published packages, and force-pushes the resulting dist contents to per-package dist branches.