### PR TITLE
Update Anvil fork URL for testing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,9 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
+        # Fork latest mainnet state
       - name: Start Anvil in background
-        run: anvil --fork-url https://nodes.sequence.app/arbitrum &
+        run: anvil --fork-url https://reth-ethereum.ithaca.xyz/nodes.sequence.app/rpc &
       - run: pnpm test
 
   # NOTE: if you'd like to see example of how to run


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Switch the Anvil fork URL in the GitHub Actions test workflow to a new mainnet RPC endpoint.