### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/packages/services/indexer/CHANGELOG.md
+++ b/packages/services/indexer/CHANGELOG.md
@@ -1,8 +1,4 @@
-<<<<<<<< HEAD:wagmi-project/packages/sequence-core-1.0.0/packages/services/metadata/CHANGELOG.md
-# @0xsequence/metadata
-========
 # @0xsequence/indexer
->>>>>>>> master:packages/services/indexer/CHANGELOG.md
 
 ## 2.3.8
 
@@ -1771,21 +1767,11 @@
 
 - update api
 
-<<<<<<<< HEAD:wagmi-project/packages/sequence-core-1.0.0/packages/services/metadata/CHANGELOG.md
-## 0.29.1
-
-### Patch Changes
-
-- metadata: ContractInfo.decimals is now optional, i.e. may be undefined
-
-  api: new APIs for user storage and isUsingGoogleMail
-========
 ## 0.29.3
 
 ### Patch Changes
 
 - indexer: add bridge contract types
->>>>>>>> master:packages/services/indexer/CHANGELOG.md
 
 ## 0.29.0
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Remove stray merge conflict markers and metadata changelog entries from the indexer CHANGELOG to keep its history scoped correctly.