### PR TITLE
Fix React Server Components CVE vulnerabilities

### DIFF
--- a/extras/docs/package.json
+++ b/extras/docs/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:*",
-    "next": "^15.4.7",
+    "next": "15.4.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/extras/web/package.json
+++ b/extras/web/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:*",
-    "next": "^15.4.7",
+    "next": "15.4.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: workspace:*
         version: link:../../repo/ui
       next:
-        specifier: ^15.4.7
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 15.4.10
+        version: 15.4.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.1.0
         version: 19.2.3
@@ -101,8 +101,8 @@ importers:
         specifier: workspace:*
         version: link:../../repo/ui
       next:
-        specifier: ^15.4.7
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 15.4.10
+        version: 15.4.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.1.0
         version: 19.2.3
@@ -188,13 +188,13 @@ importers:
         version: link:../tests
       '@0xsequence/wallet-contracts':
         specifier: ^2.0.0
-        version: 2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(bufferutil@4.0.7)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3)
+        version: 2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(bufferutil@4.0.7)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@6.0.3)
       '@babel/plugin-transform-runtime':
         specifier: ^7.19.6
         version: 7.26.9(@babel/core@7.28.5)
       babel-loader:
         specifier: ^9.1.0
-        version: 9.2.1(@babel/core@7.28.5)(webpack@5.98.0(webpack-cli@4.10.0))
+        version: 9.2.1(@babel/core@7.28.5)(webpack@5.98.0)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
@@ -203,10 +203,10 @@ importers:
         version: 7.9.2
       hardhat:
         specifier: ^2.20.1
-        version: 2.22.18(bufferutil@4.0.7)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3)
+        version: 2.22.18(bufferutil@4.0.7)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@6.0.3)
       html-webpack-plugin:
         specifier: ^5.3.1
-        version: 5.6.3(webpack@5.98.0(webpack-cli@4.10.0))
+        version: 5.6.3(webpack@5.98.0)
       webpack:
         specifier: ^5.65.0
         version: 5.98.0(webpack-cli@4.10.0)
@@ -355,13 +355,13 @@ importers:
         version: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.1
-        version: 2.2.3(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))
+        version: 2.2.3(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))
       '@nomiclabs/hardhat-web3':
         specifier: ^2.0.0
-        version: 2.0.1(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))(web3@4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 2.0.1(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(web3@4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@typechain/ethers-v5':
         specifier: ^10.1.1
-        version: 10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
       dotenv:
         specifier: ^16.0.3
         version: 16.4.7
@@ -370,7 +370,7 @@ importers:
         version: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       typechain:
         specifier: ^8.1.1
-        version: 8.3.2(typescript@5.9.3)
+        version: 8.3.2(typescript@5.8.3)
 
   packages/estimator:
     dependencies:
@@ -461,7 +461,7 @@ importers:
     devDependencies:
       '@0xsequence/wallet-contracts':
         specifier: ^2.0.0
-        version: 2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@ethersproject/providers':
         specifier: ^5.7.2
         version: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -482,7 +482,7 @@ importers:
         version: 6.1.0
       web3:
         specifier: ^4.16.0
-        version: 4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       web3-provider-engine:
         specifier: ^16.0.4
         version: 16.0.8(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -812,7 +812,7 @@ importers:
         version: 5.7.2(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3:
         specifier: ^4.16.0
-        version: 4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+        version: 4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
 
   packages/utils:
     dependencies:
@@ -905,7 +905,7 @@ importers:
         version: link:../tests
       '@0xsequence/wallet-contracts':
         specifier: ^2.0.0
-        version: 2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
+        version: 2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@istanbuljs/nyc-config-typescript':
         specifier: ^1.0.1
         version: 1.0.2(nyc@15.1.0)
@@ -914,7 +914,7 @@ importers:
         version: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3:
         specifier: ^4.16.0
-        version: 4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   packages/wallet/core:
     dependencies:
@@ -1216,8 +1216,8 @@ packages:
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/dapp-client@git+https://git@github.com:0xsequence/sequence.js.git#6a3501096be6b465b65c034b648549c0b69f8990':
-    resolution: {commit: 6a3501096be6b465b65c034b648549c0b69f8990, repo: git@github.com:0xsequence/sequence.js.git, type: git}
+  '@0xsequence/dapp-client@https://codeload.github.com/0xsequence/sequence.js/tar.gz/6a3501096be6b465b65c034b648549c0b69f8990':
+    resolution: {tarball: https://codeload.github.com/0xsequence/sequence.js/tar.gz/6a3501096be6b465b65c034b648549c0b69f8990}
     version: 3.0.0-beta.1
 
   '@0xsequence/design-system@2.1.11':
@@ -1242,8 +1242,8 @@ packages:
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/guard@git+https://git@github.com:0xsequence/sequence.js.git#501693a7bd7332ad10fd0f4a72e0dd153b44af0a':
-    resolution: {commit: 501693a7bd7332ad10fd0f4a72e0dd153b44af0a, repo: git@github.com:0xsequence/sequence.js.git, type: git}
+  '@0xsequence/guard@https://codeload.github.com/0xsequence/sequence.js/tar.gz/501693a7bd7332ad10fd0f4a72e0dd153b44af0a':
+    resolution: {tarball: https://codeload.github.com/0xsequence/sequence.js/tar.gz/501693a7bd7332ad10fd0f4a72e0dd153b44af0a}
     version: 3.0.0-beta.1
 
   '@0xsequence/hooks@0.0.0-20250924112110':
@@ -1284,8 +1284,8 @@ packages:
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/relayer@git+https://git@github.com:0xsequence/sequence.js.git#07221565e01c85b8cd0bcbb45ace5f9baf57f498':
-    resolution: {commit: 07221565e01c85b8cd0bcbb45ace5f9baf57f498, repo: git@github.com:0xsequence/sequence.js.git, type: git}
+  '@0xsequence/relayer@https://codeload.github.com/0xsequence/sequence.js/tar.gz/07221565e01c85b8cd0bcbb45ace5f9baf57f498':
+    resolution: {tarball: https://codeload.github.com/0xsequence/sequence.js/tar.gz/07221565e01c85b8cd0bcbb45ace5f9baf57f498}
     version: 3.0.0-beta.1
 
   '@0xsequence/replacer@2.3.39':
@@ -1325,15 +1325,15 @@ packages:
   '@0xsequence/wallet-contracts@3.0.1':
     resolution: {integrity: sha512-ZvZdXPE1KOYVjl9J6UdN/eBqEmuYHvlO4EUxDxG7VqCgrSiVP9S8k+mEN4aUMzOiYGwKcYY/HIkD211mvxseZQ==}
 
-  '@0xsequence/wallet-core@git+https://git@github.com:0xsequence/sequence.js.git#a623e7dad948e7b281119b34b5b6343bdf502eb8':
-    resolution: {commit: a623e7dad948e7b281119b34b5b6343bdf502eb8, repo: git@github.com:0xsequence/sequence.js.git, type: git}
+  '@0xsequence/wallet-core@https://codeload.github.com/0xsequence/sequence.js/tar.gz/a623e7dad948e7b281119b34b5b6343bdf502eb8':
+    resolution: {tarball: https://codeload.github.com/0xsequence/sequence.js/tar.gz/a623e7dad948e7b281119b34b5b6343bdf502eb8}
     version: 3.0.0-beta.1
 
   '@0xsequence/wallet-primitives@0.0.0-20250915145821':
     resolution: {integrity: sha512-EiV2ke7XmPoamppXw3eVV8gsKWJTaYFq3zhP+vltaXMncBM+0MHhKuPRLMsdbB7V88olma9aafZtuuZhlSIwhQ==}
 
-  '@0xsequence/wallet-primitives@git+https://git@github.com:0xsequence/sequence.js.git#d2967108579e84603f3b5e05685c6f331c1f3db7':
-    resolution: {commit: d2967108579e84603f3b5e05685c6f331c1f3db7, repo: git@github.com:0xsequence/sequence.js.git, type: git}
+  '@0xsequence/wallet-primitives@https://codeload.github.com/0xsequence/sequence.js/tar.gz/d2967108579e84603f3b5e05685c6f331c1f3db7':
+    resolution: {tarball: https://codeload.github.com/0xsequence/sequence.js/tar.gz/d2967108579e84603f3b5e05685c6f331c1f3db7}
     version: 3.0.0-beta.1
 
   '@0xsequence/wallet@2.3.39':
@@ -2971,8 +2971,8 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@next/env@15.5.9':
-    resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
+  '@next/env@15.4.10':
+    resolution: {integrity: sha512-knhmoJ0Vv7VRf6pZEPSnciUG1S4bIhWx+qTYBW/AjxEtlzsiNORPk8sFDCEvqLfmKuey56UB9FL1UdHEV3uBrg==}
 
   '@next/env@16.1.1':
     resolution: {integrity: sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==}
@@ -2980,8 +2980,8 @@ packages:
   '@next/eslint-plugin-next@15.5.9':
     resolution: {integrity: sha512-kUzXx0iFiXw27cQAViE1yKWnz/nF8JzRmwgMRTMh8qMY90crNsdXJRh2e+R0vBpFR3kk1yvAR7wev7+fCCb79Q==}
 
-  '@next/swc-darwin-arm64@15.5.7':
-    resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
+  '@next/swc-darwin-arm64@15.4.8':
+    resolution: {integrity: sha512-Pf6zXp7yyQEn7sqMxur6+kYcywx5up1J849psyET7/8pG2gQTVMjU3NzgIt8SeEP5to3If/SaWmaA6H6ysBr1A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2992,8 +2992,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.7':
-    resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
+  '@next/swc-darwin-x64@15.4.8':
+    resolution: {integrity: sha512-xla6AOfz68a6kq3gRQccWEvFC/VRGJmA/QuSLENSO7CZX5WIEkSz7r1FdXUjtGCQ1c2M+ndUAH7opdfLK1PQbw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -3004,8 +3004,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
-    resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
+  '@next/swc-linux-arm64-gnu@15.4.8':
+    resolution: {integrity: sha512-y3fmp+1Px/SJD+5ntve5QLZnGLycsxsVPkTzAc3zUiXYSOlTPqT8ynfmt6tt4fSo1tAhDPmryXpYKEAcoAPDJw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3016,8 +3016,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.7':
-    resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
+  '@next/swc-linux-arm64-musl@15.4.8':
+    resolution: {integrity: sha512-DX/L8VHzrr1CfwaVjBQr3GWCqNNFgyWJbeQ10Lx/phzbQo3JNAxUok1DZ8JHRGcL6PgMRgj6HylnLNndxn4Z6A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3028,8 +3028,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.7':
-    resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
+  '@next/swc-linux-x64-gnu@15.4.8':
+    resolution: {integrity: sha512-9fLAAXKAL3xEIFdKdzG5rUSvSiZTLLTCc6JKq1z04DR4zY7DbAPcRvNm3K1inVhTiQCs19ZRAgUerHiVKMZZIA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3040,8 +3040,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.7':
-    resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
+  '@next/swc-linux-x64-musl@15.4.8':
+    resolution: {integrity: sha512-s45V7nfb5g7dbS7JK6XZDcapicVrMMvX2uYgOHP16QuKH/JA285oy6HcxlKqwUNaFY/UC6EvQ8QZUOo19cBKSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3052,8 +3052,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
-    resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
+  '@next/swc-win32-arm64-msvc@15.4.8':
+    resolution: {integrity: sha512-KjgeQyOAq7t/HzAJcWPGA8X+4WY03uSCZ2Ekk98S9OgCFsb6lfBE3dbUzUuEQAN2THbwYgFfxX2yFTCMm8Kehw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -3064,8 +3064,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.7':
-    resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+  '@next/swc-win32-x64-msvc@15.4.8':
+    resolution: {integrity: sha512-Exsmf/+42fWVnLMaZHzshukTBxZrSwuuLKFvqhGHJ+mC1AokqieLY/XzAl3jc/CqhXLqLY3RRjkKJ9YnLPcRWg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6640,8 +6640,8 @@ packages:
     resolution: {integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==}
     deprecated: This library has been deprecated and usage is discouraged.
 
-  ethereumjs-abi@git+https://git@github.com:ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0:
-    resolution: {commit: ee3994657fa7a427238e6ba92a84d0b529bbcde0, repo: git@github.com:ethereumjs/ethereumjs-abi.git, type: git}
+  ethereumjs-abi@https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
+    resolution: {tarball: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0}
     version: 0.6.8
 
   ethereumjs-account@2.0.5:
@@ -8370,8 +8370,8 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  next@15.5.9:
-    resolution: {integrity: sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==}
+  next@15.4.10:
+    resolution: {integrity: sha512-itVlc79QjpKMFMRhP+kbGKaSG/gZM6RCvwhEbwmCNF06CdDiNaoHcbeg0PqkEa2GOcn8KJ0nnc7+yL7EjoYLHQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -10767,7 +10767,7 @@ snapshots:
       '@0xsequence/api': 2.3.39
       '@0xsequence/auth': 2.3.39(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))
       '@0xsequence/core': 2.3.39(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))
-      '@0xsequence/dapp-client': git+https://git@github.com:0xsequence/sequence.js.git#6a3501096be6b465b65c034b648549c0b69f8990(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
+      '@0xsequence/dapp-client': https://codeload.github.com/0xsequence/sequence.js/tar.gz/6a3501096be6b465b65c034b648549c0b69f8990(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
       '@0xsequence/design-system': 2.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(motion@12.24.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@0xsequence/ethauth': 1.0.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))
       '@0xsequence/hooks': 0.0.0-20250924112110(@0xsequence/api@2.3.39)(@0xsequence/indexer@2.3.39)(@0xsequence/metadata@2.3.39)(@0xsequence/network@2.3.39(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)))(@tanstack/react-query@5.90.16(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(viem@2.43.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1))
@@ -10808,12 +10808,12 @@ snapshots:
       '@0xsequence/utils': 2.3.39(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))
       ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
 
-  '@0xsequence/dapp-client@git+https://git@github.com:0xsequence/sequence.js.git#6a3501096be6b465b65c034b648549c0b69f8990(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)':
+  '@0xsequence/dapp-client@https://codeload.github.com/0xsequence/sequence.js/tar.gz/6a3501096be6b465b65c034b648549c0b69f8990(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)':
     dependencies:
-      '@0xsequence/guard': git+https://git@github.com:0xsequence/sequence.js.git#501693a7bd7332ad10fd0f4a72e0dd153b44af0a(typescript@5.8.3)(zod@4.2.1)
-      '@0xsequence/relayer': git+https://git@github.com:0xsequence/sequence.js.git#07221565e01c85b8cd0bcbb45ace5f9baf57f498(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
-      '@0xsequence/wallet-core': git+https://git@github.com:0xsequence/sequence.js.git#a623e7dad948e7b281119b34b5b6343bdf502eb8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
-      '@0xsequence/wallet-primitives': git+https://git@github.com:0xsequence/sequence.js.git#d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)
+      '@0xsequence/guard': https://codeload.github.com/0xsequence/sequence.js/tar.gz/501693a7bd7332ad10fd0f4a72e0dd153b44af0a(typescript@5.8.3)(zod@4.2.1)
+      '@0xsequence/relayer': https://codeload.github.com/0xsequence/sequence.js/tar.gz/07221565e01c85b8cd0bcbb45ace5f9baf57f498(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
+      '@0xsequence/wallet-core': https://codeload.github.com/0xsequence/sequence.js/tar.gz/a623e7dad948e7b281119b34b5b6343bdf502eb8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
+      '@0xsequence/wallet-primitives': https://codeload.github.com/0xsequence/sequence.js/tar.gz/d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)
       ox: 0.7.2(typescript@5.8.3)(zod@4.2.1)
     transitivePeerDependencies:
       - bufferutil
@@ -10866,7 +10866,7 @@ snapshots:
       '@0xsequence/utils': 2.3.39(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))
       ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
 
-  '@0xsequence/guard@git+https://git@github.com:0xsequence/sequence.js.git#501693a7bd7332ad10fd0f4a72e0dd153b44af0a(typescript@5.8.3)(zod@4.2.1)':
+  '@0xsequence/guard@https://codeload.github.com/0xsequence/sequence.js/tar.gz/501693a7bd7332ad10fd0f4a72e0dd153b44af0a(typescript@5.8.3)(zod@4.2.1)':
     dependencies:
       ox: 0.7.2(typescript@5.8.3)(zod@4.2.1)
     transitivePeerDependencies:
@@ -10926,9 +10926,9 @@ snapshots:
       '@0xsequence/utils': 2.3.39(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))
       ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
 
-  '@0xsequence/relayer@git+https://git@github.com:0xsequence/sequence.js.git#07221565e01c85b8cd0bcbb45ace5f9baf57f498(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)':
+  '@0xsequence/relayer@https://codeload.github.com/0xsequence/sequence.js/tar.gz/07221565e01c85b8cd0bcbb45ace5f9baf57f498(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)':
     dependencies:
-      '@0xsequence/wallet-primitives': git+https://git@github.com:0xsequence/sequence.js.git#d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)
+      '@0xsequence/wallet-primitives': https://codeload.github.com/0xsequence/sequence.js/tar.gz/d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)
       mipd: 0.0.7(typescript@5.8.3)
       ox: 0.7.2(typescript@5.8.3)(zod@4.2.1)
       viem: 2.43.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
@@ -10999,9 +10999,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@0xsequence/wallet-contracts@2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(bufferutil@4.0.7)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3)':
+  '@0xsequence/wallet-contracts@2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(bufferutil@4.0.7)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@6.0.3)':
     dependencies:
-      '@typechain/ethers-v5': 7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(ethers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+      '@typechain/ethers-v5': 7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(ethers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
       ethers: 5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       keccak256: 1.0.6
     transitivePeerDependencies:
@@ -11013,9 +11013,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@0xsequence/wallet-contracts@2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@0xsequence/wallet-contracts@2.0.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@typechain/ethers-v5': 7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+      '@typechain/ethers-v5': 7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
       ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       keccak256: 1.0.6
     transitivePeerDependencies:
@@ -11038,11 +11038,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@0xsequence/wallet-core@git+https://git@github.com:0xsequence/sequence.js.git#a623e7dad948e7b281119b34b5b6343bdf502eb8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)':
+  '@0xsequence/wallet-core@https://codeload.github.com/0xsequence/sequence.js/tar.gz/a623e7dad948e7b281119b34b5b6343bdf502eb8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)':
     dependencies:
-      '@0xsequence/guard': git+https://git@github.com:0xsequence/sequence.js.git#501693a7bd7332ad10fd0f4a72e0dd153b44af0a(typescript@5.8.3)(zod@4.2.1)
-      '@0xsequence/relayer': git+https://git@github.com:0xsequence/sequence.js.git#07221565e01c85b8cd0bcbb45ace5f9baf57f498(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
-      '@0xsequence/wallet-primitives': git+https://git@github.com:0xsequence/sequence.js.git#d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)
+      '@0xsequence/guard': https://codeload.github.com/0xsequence/sequence.js/tar.gz/501693a7bd7332ad10fd0f4a72e0dd153b44af0a(typescript@5.8.3)(zod@4.2.1)
+      '@0xsequence/relayer': https://codeload.github.com/0xsequence/sequence.js/tar.gz/07221565e01c85b8cd0bcbb45ace5f9baf57f498(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
+      '@0xsequence/wallet-primitives': https://codeload.github.com/0xsequence/sequence.js/tar.gz/d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)
       mipd: 0.0.7(typescript@5.8.3)
       ox: 0.7.2(typescript@5.8.3)(zod@4.2.1)
       viem: 2.43.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@4.2.1)
@@ -11059,7 +11059,7 @@ snapshots:
       - typescript
       - zod
 
-  '@0xsequence/wallet-primitives@git+https://git@github.com:0xsequence/sequence.js.git#d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)':
+  '@0xsequence/wallet-primitives@https://codeload.github.com/0xsequence/sequence.js/tar.gz/d2967108579e84603f3b5e05685c6f331c1f3db7(typescript@5.8.3)(zod@4.2.1)':
     dependencies:
       ox: 0.7.2(typescript@5.8.3)(zod@4.2.1)
     transitivePeerDependencies:
@@ -13377,7 +13377,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.9': {}
+  '@next/env@15.4.10': {}
 
   '@next/env@16.1.1':
     optional: true
@@ -13386,49 +13386,49 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.7':
+  '@next/swc-darwin-arm64@15.4.8':
     optional: true
 
   '@next/swc-darwin-arm64@16.1.1':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.7':
+  '@next/swc-darwin-x64@15.4.8':
     optional: true
 
   '@next/swc-darwin-x64@16.1.1':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
+  '@next/swc-linux-arm64-gnu@15.4.8':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.1.1':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.7':
+  '@next/swc-linux-arm64-musl@15.4.8':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.1.1':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.7':
+  '@next/swc-linux-x64-gnu@15.4.8':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.1.1':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.7':
+  '@next/swc-linux-x64-musl@15.4.8':
     optional: true
 
   '@next/swc-linux-x64-musl@16.1.1':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
+  '@next/swc-win32-arm64-msvc@15.4.8':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.7':
+  '@next/swc-win32-x64-msvc@15.4.8':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.1.1':
@@ -13585,15 +13585,15 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      hardhat: 2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
+      hardhat: 2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
 
-  '@nomiclabs/hardhat-web3@2.0.1(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))(web3@4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@nomiclabs/hardhat-web3@2.0.1(hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))(web3@4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
-      hardhat: 2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
-      web3: 4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      hardhat: 2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10)
+      web3: 4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   '@oxc-project/runtime@0.82.3': {}
 
@@ -15044,37 +15044,37 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@typechain/ethers-v5@10.2.1(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/providers': 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.9.3)
-      typechain: 8.3.2(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
+      typescript: 5.8.3
 
-  '@typechain/ethers-v5@7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(ethers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@typechain/ethers-v5@7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(ethers@5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/providers': 5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       ethers: 5.7.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.9.3)
-      typechain: 8.3.2(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
+      typescript: 5.8.3
 
-  '@typechain/ethers-v5@7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@typechain/ethers-v5@7.2.0(@ethersproject/abi@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(ethers@5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/providers': 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ethers: 5.7.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.9.3)
-      typechain: 8.3.2(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
+      typescript: 5.8.3
 
   '@typechain/ethers-v6@0.5.1(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@6.0.3))(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
@@ -15868,17 +15868,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0))(webpack@5.98.0(webpack-cli@4.10.0))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.98.0)':
     dependencies:
       webpack: 5.98.0(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0))':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
     dependencies:
       envinfo: 7.14.0
       webpack-cli: 4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0))(webpack-dev-server@5.2.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)(webpack-cli@4.10.0)(webpack@5.98.0))':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)(webpack-dev-server@5.2.1)':
     dependencies:
       webpack-cli: 4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0)
     optionalDependencies:
@@ -15890,9 +15890,9 @@ snapshots:
 
   abbrev@3.0.1: {}
 
-  abitype@0.7.1(typescript@5.9.3)(zod@3.25.76):
+  abitype@0.7.1(typescript@5.8.3)(zod@3.25.76):
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.8.3
     optionalDependencies:
       zod: 3.25.76
 
@@ -16193,7 +16193,7 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.98.0(webpack-cli@4.10.0)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.98.0):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
@@ -17717,7 +17717,7 @@ snapshots:
 
   eth-sig-util@1.4.2:
     dependencies:
-      ethereumjs-abi: git+https://git@github.com:ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0
+      ethereumjs-abi: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0
       ethereumjs-util: 5.2.1
 
   ethereum-cryptography@0.1.3:
@@ -17757,7 +17757,7 @@ snapshots:
       bn.js: 4.12.1
       ethereumjs-util: 6.2.1
 
-  ethereumjs-abi@git+https://git@github.com:ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0:
+  ethereumjs-abi@https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
     dependencies:
       bn.js: 4.12.2
       ethereumjs-util: 6.2.1
@@ -18553,7 +18553,7 @@ snapshots:
       whatwg-mimetype: 3.0.0
     optional: true
 
-  hardhat@2.22.18(bufferutil@4.0.7)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3):
+  hardhat@2.22.18(bufferutil@4.0.7)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@6.0.3):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -18600,8 +18600,8 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10(bufferutil@4.0.7)(utf-8-validate@6.0.3)
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - bufferutil
       - c-kzg
@@ -18663,7 +18663,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10):
+  hardhat@2.28.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10):
     dependencies:
       '@ethereumjs/util': 9.1.0
       '@ethersproject/abi': 5.8.0
@@ -18705,8 +18705,8 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -18784,7 +18784,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-webpack-plugin@5.6.3(webpack@5.98.0(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.6.3(webpack@5.98.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -19933,9 +19933,9 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.4.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 15.5.9
+      '@next/env': 15.4.10
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001762
       postcss: 8.4.31
@@ -19943,14 +19943,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
+      '@next/swc-darwin-arm64': 15.4.8
+      '@next/swc-darwin-x64': 15.4.8
+      '@next/swc-linux-arm64-gnu': 15.4.8
+      '@next/swc-linux-arm64-musl': 15.4.8
+      '@next/swc-linux-x64-gnu': 15.4.8
+      '@next/swc-linux-x64-musl': 15.4.8
+      '@next/swc-win32-arm64-msvc': 15.4.8
+      '@next/swc-win32-x64-msvc': 15.4.8
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -21528,7 +21528,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.11(webpack@5.98.0(webpack-cli@4.10.0)):
+  terser-webpack-plugin@5.3.11(webpack@5.98.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -21653,10 +21653,6 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-essentials@7.0.3(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
   ts-morph@12.0.0:
     dependencies:
       '@ts-morph/common': 0.11.1
@@ -21697,6 +21693,25 @@ snapshots:
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@25.0.3)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.0.3
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3):
     dependencies:
@@ -21809,22 +21824,6 @@ snapshots:
       ts-command-line-args: 2.5.1
       ts-essentials: 7.0.3(typescript@5.8.3)
       typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typechain@8.3.2(typescript@5.9.3):
-    dependencies:
-      '@types/prettier': 2.7.3
-      debug: 4.4.0(supports-color@8.1.1)
-      fs-extra: 7.0.1
-      glob: 7.1.7
-      js-sha3: 0.8.0
-      lodash: 4.17.21
-      mkdirp: 1.0.4
-      prettier: 2.8.8
-      ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.9.3)
-      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22362,9 +22361,9 @@ snapshots:
     dependencies:
       web3-types: 1.10.0
 
-  web3-eth-abi@4.4.1(typescript@5.9.3)(zod@3.25.76):
+  web3-eth-abi@4.4.1(typescript@5.8.3)(zod@3.25.76):
     dependencies:
-      abitype: 0.7.1(typescript@5.9.3)(zod@3.25.76)
+      abitype: 0.7.1(typescript@5.8.3)(zod@3.25.76)
       web3-errors: 1.3.1
       web3-types: 1.10.0
       web3-utils: 4.3.3
@@ -22383,13 +22382,13 @@ snapshots:
       web3-utils: 4.3.3
       web3-validator: 2.0.6
 
-  web3-eth-contract@4.7.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  web3-eth-contract@4.7.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@ethereumjs/rlp': 5.0.2
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-errors: 1.3.1
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      web3-eth-abi: 4.4.1(typescript@5.9.3)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth-abi: 4.4.1(typescript@5.8.3)(zod@3.25.76)
       web3-types: 1.10.0
       web3-utils: 4.3.3
       web3-validator: 2.0.6
@@ -22400,13 +22399,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth-contract@4.7.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76):
+  web3-eth-contract@4.7.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76):
     dependencies:
       '@ethereumjs/rlp': 5.0.2
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-errors: 1.3.1
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
-      web3-eth-abi: 4.4.1(typescript@5.9.3)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth-abi: 4.4.1(typescript@5.8.3)(zod@3.25.76)
       web3-types: 1.10.0
       web3-utils: 4.3.3
       web3-validator: 2.0.6
@@ -22417,13 +22416,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth-ens@4.4.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  web3-eth-ens@4.4.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-errors: 1.3.1
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       web3-net: 4.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-types: 1.10.0
       web3-utils: 4.3.3
@@ -22435,13 +22434,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth-ens@4.4.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76):
+  web3-eth-ens@4.4.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-errors: 1.3.1
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
-      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
       web3-net: 4.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-types: 1.10.0
       web3-utils: 4.3.3
@@ -22460,10 +22459,10 @@ snapshots:
       web3-utils: 4.3.3
       web3-validator: 2.0.6
 
-  web3-eth-personal@4.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  web3-eth-personal@4.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       web3-rpc-methods: 1.3.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-types: 1.10.0
       web3-utils: 4.3.3
@@ -22475,10 +22474,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth-personal@4.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76):
+  web3-eth-personal@4.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76):
     dependencies:
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@6.0.3)
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
       web3-rpc-methods: 1.3.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-types: 1.10.0
       web3-utils: 4.3.3
@@ -22490,12 +22489,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth@4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  web3-eth@4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-errors: 1.3.1
-      web3-eth-abi: 4.4.1(typescript@5.9.3)(zod@3.25.76)
+      web3-eth-abi: 4.4.1(typescript@5.8.3)(zod@3.25.76)
       web3-eth-accounts: 4.3.1
       web3-net: 4.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-providers-ws: 4.0.8(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -22510,12 +22509,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth@4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76):
+  web3-eth@4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76):
     dependencies:
       setimmediate: 1.0.5
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-errors: 1.3.1
-      web3-eth-abi: 4.4.1(typescript@5.9.3)(zod@3.25.76)
+      web3-eth-abi: 4.4.1(typescript@5.8.3)(zod@3.25.76)
       web3-eth-accounts: 4.3.1
       web3-net: 4.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-providers-ws: 4.0.8(bufferutil@4.0.9)(utf-8-validate@6.0.3)
@@ -22684,17 +22683,17 @@ snapshots:
       web3-types: 1.10.0
       zod: 3.25.76
 
-  web3@4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  web3@4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-errors: 1.3.1
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      web3-eth-abi: 4.4.1(typescript@5.9.3)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth-abi: 4.4.1(typescript@5.8.3)(zod@3.25.76)
       web3-eth-accounts: 4.3.1
-      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      web3-eth-ens: 4.4.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth-ens: 4.4.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      web3-eth-personal: 4.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       web3-net: 4.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       web3-providers-http: 4.2.0
       web3-providers-ws: 4.0.8(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -22710,17 +22709,17 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3@4.16.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76):
+  web3@4.16.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76):
     dependencies:
       web3-core: 4.7.1(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-errors: 1.3.1
-      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
-      web3-eth-abi: 4.4.1(typescript@5.9.3)(zod@3.25.76)
+      web3-eth: 4.11.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth-abi: 4.4.1(typescript@5.8.3)(zod@3.25.76)
       web3-eth-accounts: 4.3.1
-      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
-      web3-eth-ens: 4.4.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth-contract: 4.7.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth-ens: 4.4.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
       web3-eth-iban: 4.0.7
-      web3-eth-personal: 4.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.3)(zod@3.25.76)
+      web3-eth-personal: 4.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@6.0.3)(zod@3.25.76)
       web3-net: 4.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.3)
       web3-providers-http: 4.2.0
       web3-providers-ws: 4.0.8(bufferutil@4.0.9)(utf-8-validate@6.0.3)
@@ -22749,9 +22748,9 @@ snapshots:
   webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0))(webpack@5.98.0(webpack-cli@4.10.0))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-dev-server@5.2.1)(webpack@5.98.0))(webpack-dev-server@5.2.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)(webpack-cli@4.10.0)(webpack@5.98.0))
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.98.0)
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)(webpack-dev-server@5.2.1)
       colorette: 2.0.20
       commander: 7.2.0
       cross-spawn: 7.0.6
@@ -22764,7 +22763,7 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 5.2.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)(webpack-cli@4.10.0)(webpack@5.98.0)
 
-  webpack-dev-middleware@7.4.5(webpack@5.98.0(webpack-cli@4.10.0)):
+  webpack-dev-middleware@7.4.5(webpack@5.98.0):
     dependencies:
       colorette: 2.0.20
       memfs: 4.51.1
@@ -22803,7 +22802,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.98.0(webpack-cli@4.10.0))
+      webpack-dev-middleware: 7.4.5(webpack@5.98.0)
       ws: 8.18.3(bufferutil@4.0.7)(utf-8-validate@6.0.3)
     optionalDependencies:
       webpack: 5.98.0(webpack-cli@4.10.0)
@@ -22844,7 +22843,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(webpack@5.98.0(webpack-cli@4.10.0))
+      terser-webpack-plugin: 5.3.11(webpack@5.98.0)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/wagmi-project/packages/sequence-core-1.0.0/extras/docs/package.json
+++ b/wagmi-project/packages/sequence-core-1.0.0/extras/docs/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:*",
-    "next": "^15.4.7",
+    "next": "15.4.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/wagmi-project/packages/sequence-core-1.0.0/extras/web/package.json
+++ b/wagmi-project/packages/sequence-core-1.0.0/extras/web/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:*",
-    "next": "^15.4.7",
+    "next": "15.4.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
Updated dependencies to fix Next.js and React CVE vulnerabilities.

The fix-react2shell-next tool automatically updated the following packages to their secure versions:
- next
- react-server-dom-webpack
- react-server-dom-parcel  
- react-server-dom-turbopack

All package.json files have been scanned and vulnerable versions have been patched to the correct fixed versions based on the official React advisory.

## Summary by Sourcery

Build:
- Bump Next.js from 15.4.7 to 15.4.10 in docs and web packages and refresh pnpm lockfile to align with the new version.