### PR TITLE
Revert "Delete lib/signals-implicit-mode/lib/sequence-v3/script/DeployMocks.s…"

### DIFF
--- a/lib/signals-implicit-mode/lib/sequence-v3/script/DeployMocks.s.sol
+++ b/lib/signals-implicit-mode/lib/sequence-v3/script/DeployMocks.s.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import { SingletonDeployer, console } from "lib/erc2470-libs/script/SingletonDeployer.s.sol";
+
+import { Emitter } from "test/mocks/Emitter.sol";
+
+contract DeployMocks is SingletonDeployer {
+
+  function run() external {
+    uint256 pk = vm.envUint("PRIVATE_KEY");
+
+    bytes32 salt = bytes32(0);
+
+    bytes memory initCode = abi.encodePacked(type(Emitter).creationCode);
+    _deployIfNotAlready("Emitter", initCode, salt, pk);
+  }
+
+}


### PR DESCRIPTION
Reverts Dargon789/sequence.js#203

## Summary by Sourcery

Enhancements:
- Reintroduce the DeployMocks Solidity script to deploy the Emitter mock contract via the shared singleton deployer.