### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 on: [push]
 
 name: tests
+permissions:
+  contents: read
 
 jobs:
   install:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/sequence.js/security/code-scanning/40](https://github.com/Dargon789/sequence.js/security/code-scanning/40)

The fix is to explicitly define a minimal `permissions` block so that the `GITHUB_TOKEN` granted to this workflow is restricted to read‑only repository contents, which suffices for `actions/checkout` and typical dependency installation/build/test steps. The cleanest way is to add a single root‑level `permissions:` block that will apply to all jobs, rather than repeating it for each job.

Concretely, in `.github/workflows/tests.yml`, add:

```yaml
name: tests
permissions:
  contents: read
```

directly under the existing `name: tests` line (line 3). This will limit all jobs (`install`, `build`, `tests`, and any uncommented future jobs) to read‑only access to repository contents unless they define their own `permissions:` block. No imports, methods, or further definitions are needed since this is purely a workflow configuration change and does not alter any job steps or functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add a root-level permissions block to the tests GitHub Actions workflow to limit repository contents access to read-only for all jobs.