### PR TITLE
core: allow native self transfer (#978)

### DIFF
--- a/packages/wallet/core/src/wallet.ts
+++ b/packages/wallet/core/src/wallet.ts
@@ -342,7 +342,7 @@ export class Wallet {
         if (call.delegateCall) {
           throw new Error('delegate calls are not allowed in safe mode')
         }
-        if (Address.isEqual(call.to, this.address)) {
+        if (Address.isEqual(call.to, this.address) && call.data !== '0x') {
           throw new Error('calls to the wallet contract itself are not allowed in safe mode')
         }
       }
@@ -455,7 +455,7 @@ export class Wallet {
         if (call.delegateCall) {
           throw new Error('delegate calls are not allowed in safe mode')
         }
-        if (Address.isEqual(call.to, this.address)) {
+        if (Address.isEqual(call.to, this.address) && call.data !== '0x') {
           throw new Error('calls to the wallet contract itself are not allowed in safe mode')
         }
       }

--- a/packages/wallet/wdk/test/transactions.test.ts
+++ b/packages/wallet/wdk/test/transactions.test.ts
@@ -481,10 +481,29 @@ describe('Transactions', () => {
     const txId1 = manager.transactions.request(wallet!, Network.ChainId.ARBITRUM, [
       {
         to: wallet!,
+        data: '0x1234',
       },
     ])
 
     await expect(txId1).rejects.toThrow()
+  })
+
+  it('Should allow native token transfer to self in safe mode', async () => {
+    const manager = newManager()
+    const wallet = await manager.wallets.signUp({
+      mnemonic: Mnemonic.random(Mnemonic.english),
+      kind: 'mnemonic',
+      noGuard: true,
+    })
+
+    const txId1 = await manager.transactions.request(wallet!, Network.ChainId.ARBITRUM, [
+      {
+        to: wallet!,
+        value: 1n,
+      },
+    ])
+
+    expect(txId1).toBeDefined()
   })
 
   it('Should allow transactions to self in unsafe mode', async () => {


### PR DESCRIPTION
## Summary by Sourcery

Allow native token transfers to the wallet’s own address in safe mode while still blocking contract calls with non-empty calldata to self.

Bug Fixes:
- Relax safe-mode self-call restriction to permit native token transfers with empty calldata to the wallet’s own address.

Tests:
- Add coverage ensuring native token self-transfers are accepted in safe mode and self-calls with calldata remain rejected.