### PR TITLE
Potential fix for code scanning alert no. 82: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on_pr_pnpm-format-label.yml
+++ b/.github/workflows/on_pr_pnpm-format-label.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   proto:
     if: ${{ github.event.label.name == 'pnpm format' }}


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/sequence.js/security/code-scanning/82](https://github.com/Dargon789/sequence.js/security/code-scanning/82)

Add an explicit top-level `permissions` block in `.github/workflows/on_pr_pnpm-format-label.yml` so all jobs (including the reusable-workflow `proto` job) run with least privilege by default. Keep existing behavior by preserving `rm` job’s existing explicit permissions (`contents: read`, `issues: write`) since it needs to delete a label via API. The best minimal, non-breaking fix is:

- Add at workflow root (after `on` block, before `jobs`):
  - `permissions:`
  - `contents: read`

This satisfies CodeQL for missing explicit permissions and avoids broad default token scopes. No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Declare a top-level `permissions: contents: read` block in the `on_pr_pnpm-format-label` GitHub Actions workflow so all jobs default to read-only token access.