### PR TITLE
Enforce minimum age limitation for packages

### DIFF
--- a/extras/docs/package.json
+++ b/extras/docs/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:^",
-    "next": "^15.5.14",
+    "next": "^15.5.15",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },

--- a/extras/web/package.json
+++ b/extras/web/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:^",
-    "next": "^15.5.14",
+    "next": "^15.5.15",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "ox": "^0.9.17"
     }
   },
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=18"
   },

--- a/packages/services/api/CHANGELOG.md
+++ b/packages/services/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/api
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/api/CHANGELOG.md
+++ b/packages/services/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/api
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/api",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "api sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/api",
   "author": "Sequence Platforms ULC",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/api",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "api sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/api",
   "author": "Sequence Platforms ULC",

--- a/packages/services/builder/CHANGELOG.md
+++ b/packages/services/builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/builder
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/builder/CHANGELOG.md
+++ b/packages/services/builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/builder
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/builder/package.json
+++ b/packages/services/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/builder",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "builder sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/builder",
   "author": "Sequence Platforms ULC",

--- a/packages/services/builder/package.json
+++ b/packages/services/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/builder",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "builder sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/builder",
   "author": "Sequence Platforms ULC",

--- a/packages/services/guard/CHANGELOG.md
+++ b/packages/services/guard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/guard
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/guard/CHANGELOG.md
+++ b/packages/services/guard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/guard
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/guard/package.json
+++ b/packages/services/guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/guard",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "guard sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/guard",
   "author": "Sequence Platforms ULC",

--- a/packages/services/guard/package.json
+++ b/packages/services/guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/guard",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "guard sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/guard",
   "author": "Sequence Platforms ULC",

--- a/packages/services/identity-instrument/CHANGELOG.md
+++ b/packages/services/identity-instrument/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/identity-instrument
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/identity-instrument/CHANGELOG.md
+++ b/packages/services/identity-instrument/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/identity-instrument
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/identity-instrument/package.json
+++ b/packages/services/identity-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/identity-instrument",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/services/identity-instrument/package.json
+++ b/packages/services/identity-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/identity-instrument",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/services/indexer/CHANGELOG.md
+++ b/packages/services/indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/indexer
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/indexer/CHANGELOG.md
+++ b/packages/services/indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/indexer
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/indexer/package.json
+++ b/packages/services/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/indexer",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "indexer sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/indexer",
   "author": "Sequence Platforms ULC",

--- a/packages/services/indexer/package.json
+++ b/packages/services/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/indexer",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "indexer sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/indexer",
   "author": "Sequence Platforms ULC",

--- a/packages/services/marketplace/CHANGELOG.md
+++ b/packages/services/marketplace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/marketplace
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/marketplace/CHANGELOG.md
+++ b/packages/services/marketplace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/marketplace
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/marketplace/package.json
+++ b/packages/services/marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/marketplace",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "marketplace sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/marketplace",
   "author": "Sequence Platforms ULC",

--- a/packages/services/marketplace/package.json
+++ b/packages/services/marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/marketplace",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "marketplace sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/marketplace",
   "author": "Sequence Platforms ULC",

--- a/packages/services/metadata/CHANGELOG.md
+++ b/packages/services/metadata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/metadata
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/metadata/CHANGELOG.md
+++ b/packages/services/metadata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/metadata
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/metadata/package.json
+++ b/packages/services/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/metadata",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/services/metadata/package.json
+++ b/packages/services/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/metadata",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/services/relayer/CHANGELOG.md
+++ b/packages/services/relayer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @0xsequence/relayer
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+- Updated dependencies
+  - @0xsequence/wallet-primitives@3.0.8
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/relayer/CHANGELOG.md
+++ b/packages/services/relayer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @0xsequence/relayer
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+- Updated dependencies
+  - @0xsequence/wallet-primitives@3.0.9
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/relayer/package.json
+++ b/packages/services/relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/relayer",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/services/relayer/package.json
+++ b/packages/services/relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/relayer",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/services/userdata/CHANGELOG.md
+++ b/packages/services/userdata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/userdata
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/services/userdata/CHANGELOG.md
+++ b/packages/services/userdata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/userdata
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/services/userdata/package.json
+++ b/packages/services/userdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/userdata",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "userdata sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/userdata",
   "author": "Sequence Platforms ULC",

--- a/packages/services/userdata/package.json
+++ b/packages/services/userdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/userdata",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "userdata sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/userdata",
   "author": "Sequence Platforms ULC",

--- a/packages/utils/abi/CHANGELOG.md
+++ b/packages/utils/abi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/abi
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/utils/abi/CHANGELOG.md
+++ b/packages/utils/abi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/abi
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/utils/abi/package.json
+++ b/packages/utils/abi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/abi",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "abi sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/utils/abi",
   "author": "Sequence Platforms ULC",

--- a/packages/utils/abi/package.json
+++ b/packages/utils/abi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/abi",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "abi sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/utils/abi",
   "author": "Sequence Platforms ULC",

--- a/packages/wallet/core/CHANGELOG.md
+++ b/packages/wallet/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @0xsequence/wallet-core
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+- Updated dependencies
+  - @0xsequence/guard@3.0.8
+  - @0xsequence/relayer@3.0.8
+  - @0xsequence/wallet-primitives@3.0.8
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/wallet/core/CHANGELOG.md
+++ b/packages/wallet/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @0xsequence/wallet-core
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+- Updated dependencies
+  - @0xsequence/guard@3.0.9
+  - @0xsequence/relayer@3.0.9
+  - @0xsequence/wallet-primitives@3.0.9
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/wallet/core/package.json
+++ b/packages/wallet/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-core",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/core/package.json
+++ b/packages/wallet/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-core",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/core/src/wallet.ts
+++ b/packages/wallet/core/src/wallet.ts
@@ -25,6 +25,51 @@ export const DefaultWalletOptions: WalletOptions = {
   guest: Constants.DefaultGuestAddress,
 }
 
+const FeeOptionsStubSignature: SequenceSignature.SignatureOfSignerLeaf = {
+  type: 'eth_sign',
+  r: 0x1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn,
+  s: 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n,
+  yParity: 0,
+}
+
+function stubFeeOptionsTopology(topology: Config.Topology): SequenceSignature.RawTopology {
+  if (Array.isArray(topology)) {
+    return [stubFeeOptionsTopology(topology[0]), stubFeeOptionsTopology(topology[1])]
+  }
+
+  if (Config.isSignerLeaf(topology)) {
+    return {
+      type: 'unrecovered-signer',
+      weight: topology.weight,
+      signature: FeeOptionsStubSignature,
+    }
+  }
+
+  if (Config.isNestedLeaf(topology)) {
+    return {
+      type: 'nested',
+      weight: topology.weight,
+      threshold: topology.threshold,
+      tree: stubFeeOptionsTopology(topology.tree),
+    }
+  }
+
+  return topology
+}
+
+function buildFeeOptionsStubSignature(status: WalletStatusWithOnchain): Hex.Hex {
+  return Bytes.toHex(
+    SequenceSignature.encodeSignature({
+      noChainId: status.chainId === 0,
+      configuration: {
+        ...status.configuration,
+        topology: stubFeeOptionsTopology(status.configuration.topology),
+      },
+      suffix: status.pendingUpdates.map(({ signature }) => signature),
+    }),
+  )
+}
+
 export type WalletStatus = {
   address: Address.Address
   isDeployed: boolean
@@ -499,7 +544,7 @@ export class Wallet {
     payload: Payload.Calls,
   ): Promise<{ to: Address.Address; data: Hex.Hex }> {
     const status = await this.getStatus(provider)
-    const signature = '0x0001' as Hex.Hex
+    const signature = buildFeeOptionsStubSignature(status)
 
     const executeData = AbiFunction.encodeData(Constants.EXECUTE, [Bytes.toHex(Payload.encode(payload)), signature])
 

--- a/packages/wallet/core/test/wallet-fee-options.test.ts
+++ b/packages/wallet/core/test/wallet-fee-options.test.ts
@@ -6,6 +6,8 @@ import { State, Wallet } from '../src/index.js'
 
 const SIGNER = '0x1234567890123456789012345678901234567890' as Address.Address
 const TARGET = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address.Address
+const FEE_OPTIONS_STUB_SIGNATURE =
+  '0x040001711fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0' as Hex.Hex
 
 const configuration: Config.Config = {
   threshold: 1n,
@@ -74,7 +76,10 @@ describe('Wallet.buildFeeOptionsTransaction', () => {
     const { wallet, imageHash } = await createWallet()
     const transaction = await wallet.buildFeeOptionsTransaction(providerFor({ deployed: true, imageHash }), payload)
 
-    const expectedData = AbiFunction.encodeData(Constants.EXECUTE, [Bytes.toHex(Payload.encode(payload)), '0x0001'])
+    const expectedData = AbiFunction.encodeData(Constants.EXECUTE, [
+      Bytes.toHex(Payload.encode(payload)),
+      FEE_OPTIONS_STUB_SIGNATURE,
+    ])
 
     expect(Address.isEqual(transaction.to, wallet.address)).toBe(true)
     expect(transaction.data).toBe(expectedData)
@@ -88,7 +93,7 @@ describe('Wallet.buildFeeOptionsTransaction', () => {
 
     const expectedExecuteData = AbiFunction.encodeData(Constants.EXECUTE, [
       Bytes.toHex(Payload.encode(payload)),
-      '0x0001',
+      FEE_OPTIONS_STUB_SIGNATURE,
     ])
 
     expect(Address.isEqual(transaction.to, Constants.DefaultGuestAddress)).toBe(true)

--- a/packages/wallet/dapp-client/CHANGELOG.md
+++ b/packages/wallet/dapp-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @0xsequence/dapp-client
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+- Updated dependencies
+  - @0xsequence/guard@3.0.9
+  - @0xsequence/relayer@3.0.9
+  - @0xsequence/wallet-core@3.0.9
+  - @0xsequence/wallet-primitives@3.0.9
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/wallet/dapp-client/CHANGELOG.md
+++ b/packages/wallet/dapp-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @0xsequence/dapp-client
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+- Updated dependencies
+  - @0xsequence/guard@3.0.8
+  - @0xsequence/relayer@3.0.8
+  - @0xsequence/wallet-core@3.0.8
+  - @0xsequence/wallet-primitives@3.0.8
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/wallet/dapp-client/package.json
+++ b/packages/wallet/dapp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/dapp-client",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/dapp-client/package.json
+++ b/packages/wallet/dapp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/dapp-client",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/primitives/CHANGELOG.md
+++ b/packages/wallet/primitives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/wallet-primitives
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/wallet/primitives/CHANGELOG.md
+++ b/packages/wallet/primitives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/wallet-primitives
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/wallet/primitives/package.json
+++ b/packages/wallet/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-primitives",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/primitives/package.json
+++ b/packages/wallet/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-primitives",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/wdk/CHANGELOG.md
+++ b/packages/wallet/wdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @0xsequence/wallet-wdk
 
+## 3.0.9
+
+### Patch Changes
+
+- Fee options fixes
+- Updated dependencies
+  - @0xsequence/guard@3.0.9
+  - @0xsequence/identity-instrument@3.0.9
+  - @0xsequence/relayer@3.0.9
+  - @0xsequence/wallet-core@3.0.9
+  - @0xsequence/wallet-primitives@3.0.9
+
 ## 3.0.8
 
 ### Patch Changes

--- a/packages/wallet/wdk/CHANGELOG.md
+++ b/packages/wallet/wdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @0xsequence/wallet-wdk
 
+## 3.0.8
+
+### Patch Changes
+
+- Bug fix for relayer fee options handling
+- Updated dependencies
+  - @0xsequence/guard@3.0.8
+  - @0xsequence/identity-instrument@3.0.8
+  - @0xsequence/relayer@3.0.8
+  - @0xsequence/wallet-core@3.0.8
+  - @0xsequence/wallet-primitives@3.0.8
+
 ## 3.0.7
 
 ### Patch Changes

--- a/packages/wallet/wdk/package.json
+++ b/packages/wallet/wdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-wdk",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/wdk/package.json
+++ b/packages/wallet/wdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-wdk",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:^
         version: link:../../repo/ui
       next:
-        specifier: ^15.5.14
-        version: 15.5.14(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^15.5.15
+        version: 15.5.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -76,8 +76,8 @@ importers:
         specifier: workspace:^
         version: link:../../repo/ui
       next:
-        specifier: ^15.5.14
-        version: 15.5.14(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^15.5.15
+        version: 15.5.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -530,7 +530,7 @@ importers:
         version: 7.0.1(eslint@9.39.2)
       eslint-plugin-turbo:
         specifier: ^2.6.3
-        version: 2.6.3(eslint@9.39.2)(turbo@2.9.8)
+        version: 2.6.3(eslint@9.39.2)(turbo@2.9.9)
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -720,8 +720,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -1104,56 +1104,56 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@next/env@15.5.14':
-    resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
+  '@next/env@15.5.15':
+    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
 
   '@next/eslint-plugin-next@15.5.9':
     resolution: {integrity: sha512-kUzXx0iFiXw27cQAViE1yKWnz/nF8JzRmwgMRTMh8qMY90crNsdXJRh2e+R0vBpFR3kk1yvAR7wev7+fCCb79Q==}
 
-  '@next/swc-darwin-arm64@15.5.14':
-    resolution: {integrity: sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==}
+  '@next/swc-darwin-arm64@15.5.15':
+    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.14':
-    resolution: {integrity: sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==}
+  '@next/swc-darwin-x64@15.5.15':
+    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.14':
-    resolution: {integrity: sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==}
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.14':
-    resolution: {integrity: sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==}
+  '@next/swc-linux-arm64-musl@15.5.15':
+    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.14':
-    resolution: {integrity: sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==}
+  '@next/swc-linux-x64-gnu@15.5.15':
+    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.14':
-    resolution: {integrity: sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==}
+  '@next/swc-linux-x64-musl@15.5.15':
+    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.14':
-    resolution: {integrity: sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==}
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.14':
-    resolution: {integrity: sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==}
+  '@next/swc-win32-x64-msvc@15.5.15':
+    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1331,8 +1331,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@turbo/darwin-64@2.9.9':
+    resolution: {integrity: sha512-hTEiNu2ABZZOO1qbjnKASI8eF3BdOOzU6iKv5w5uGOK65DDMc10cS40N1kqM99YT0uSAGUwNu6GdFctRPeEeVA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@turbo/darwin-arm64@2.9.8':
     resolution: {integrity: sha512-nKRFI5ZhCGUi4eXNlrojzWcT/CehMj0raot1WE4lw5qf66ZxZHbRbBqcwNEy+ZLY7RkJJRY+TaU89fuj3BcgGg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.9':
+    resolution: {integrity: sha512-MinO40EEcP5mJiTVpfjtEulsEBhVeryfq21QhYtJZ8hQJLHGgy459rcmDVAY8/JERe4dkVU4KW+zoLF22o01EA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1345,8 +1355,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@turbo/linux-64@2.9.9':
+    resolution: {integrity: sha512-7JNLw88Isk+gMlbsC8pulLDkrqe2B827ZsKFEHilb17AC6Xn/62pzH7afjY7fEU6Ayp4XP/vGhlRWOzqBvBvIQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@turbo/linux-arm64@2.9.8':
     resolution: {integrity: sha512-v6S3HuKVoa9CEx16IxKj1i/+crxXx22A9O80zW1350zyUlcX0T/zLOxVf1k+ruK/7ssXnDJVg8uSYOxlYRedlA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.9':
+    resolution: {integrity: sha512-0pnXDwPw1rHii98JZPRg7SvsjIzy7jrhkwGU9Jy5fVYoMdYd3P2vbtLfII+OJ0Mm4Ar5yykdHDTz3RWiRI1o9g==}
     cpu: [arm64]
     os: [linux]
 
@@ -1355,8 +1375,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@turbo/windows-64@2.9.9':
+    resolution: {integrity: sha512-vjDQycz4gQVvIq4n2rPtiiIESwJlAc406qtkiZlqyL+fHZEd9SxYNlBIFYtc5cuMuwrk+sIKrhN7XvwjmvS9YQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@turbo/windows-arm64@2.9.8':
     resolution: {integrity: sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.9':
+    resolution: {integrity: sha512-V6NiH43oCctepbOdQFp7UjqLyK8p6Tt824QA+G4TE+B1BBHu80A0W8OCL+H7uBJ3XZjAj/hvPDw3k3l65DoDGw==}
     cpu: [arm64]
     os: [win32]
 
@@ -1675,7 +1705,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1733,8 +1763,8 @@ packages:
   camel-case@3.0.0:
     resolution: {integrity: sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==}
 
-  caniuse-lite@1.0.30001781:
-    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   cbor2@1.12.0:
     resolution: {integrity: sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==}
@@ -2818,8 +2848,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2833,8 +2863,8 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  next@15.5.14:
-    resolution: {integrity: sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==}
+  next@15.5.15:
+    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -3058,8 +3088,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3552,6 +3582,10 @@ packages:
 
   turbo@2.9.8:
     resolution: {integrity: sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A==}
+    hasBin: true
+
+  turbo@2.9.9:
+    resolution: {integrity: sha512-3xfzXE/yTjhh0S5dIWlE+3E+J9A09REpLI1ZqVh2+HrNZoVzZn0pkvjiRgVK/Ev3PF9XnaTwCntTx+CADWXcyA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -4111,7 +4145,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4336,7 +4370,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -4395,34 +4429,34 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@next/env@15.5.14': {}
+  '@next/env@15.5.15': {}
 
   '@next/eslint-plugin-next@15.5.9':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.14':
+  '@next/swc-darwin-arm64@15.5.15':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.14':
+  '@next/swc-darwin-x64@15.5.15':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.14':
+  '@next/swc-linux-arm64-gnu@15.5.15':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.14':
+  '@next/swc-linux-arm64-musl@15.5.15':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.14':
+  '@next/swc-linux-x64-gnu@15.5.15':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.14':
+  '@next/swc-linux-x64-musl@15.5.15':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.14':
+  '@next/swc-win32-arm64-msvc@15.5.15':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.14':
+  '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -4545,7 +4579,13 @@ snapshots:
   '@turbo/darwin-64@2.9.8':
     optional: true
 
+  '@turbo/darwin-64@2.9.9':
+    optional: true
+
   '@turbo/darwin-arm64@2.9.8':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.9':
     optional: true
 
   '@turbo/gen@1.13.4(@types/node@25.3.0)(typescript@6.0.3)':
@@ -4571,13 +4611,25 @@ snapshots:
   '@turbo/linux-64@2.9.8':
     optional: true
 
+  '@turbo/linux-64@2.9.9':
+    optional: true
+
   '@turbo/linux-arm64@2.9.8':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.9':
     optional: true
 
   '@turbo/windows-64@2.9.8':
     optional: true
 
+  '@turbo/windows-64@2.9.9':
+    optional: true
+
   '@turbo/windows-arm64@2.9.8':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.9':
     optional: true
 
   '@turbo/workspaces@1.13.4(@types/node@25.3.0)':
@@ -4990,7 +5042,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.7
-      caniuse-lite: 1.0.30001781
+      caniuse-lite: 1.0.30001791
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.2(browserslist@4.28.1)
@@ -5026,7 +5078,7 @@ snapshots:
       no-case: 2.3.2
       upper-case: 1.1.3
 
-  caniuse-lite@1.0.30001781: {}
+  caniuse-lite@1.0.30001791: {}
 
   cbor2@1.12.0: {}
 
@@ -5447,11 +5499,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.6.3(eslint@9.39.2)(turbo@2.9.8):
+  eslint-plugin-turbo@2.6.3(eslint@9.39.2)(turbo@2.9.9):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.2
-      turbo: 2.9.8
+      turbo: 2.9.9
 
   eslint-scope@8.4.0:
     dependencies:
@@ -6277,7 +6329,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -6285,24 +6337,24 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.5.14(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 15.5.14
+      '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001781
+      caniuse-lite: 1.0.30001791
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.14
-      '@next/swc-darwin-x64': 15.5.14
-      '@next/swc-linux-arm64-gnu': 15.5.14
-      '@next/swc-linux-arm64-musl': 15.5.14
-      '@next/swc-linux-x64-gnu': 15.5.14
-      '@next/swc-linux-x64-musl': 15.5.14
-      '@next/swc-win32-arm64-msvc': 15.5.14
-      '@next/swc-win32-x64-msvc': 15.5.14
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6557,13 +6609,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.8:
+  postcss@8.5.14:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7132,6 +7184,15 @@ snapshots:
       '@turbo/windows-64': 2.9.8
       '@turbo/windows-arm64': 2.9.8
 
+  turbo@2.9.9:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.9
+      '@turbo/darwin-arm64': 2.9.9
+      '@turbo/linux-64': 2.9.9
+      '@turbo/linux-arm64': 2.9.9
+      '@turbo/windows-64': 2.9.9
+      '@turbo/windows-arm64': 2.9.9
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -7253,7 +7314,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.8
+      postcss: 8.5.14
       rollup: 4.53.4
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+minimumReleaseAge: 20160 # 60 * 24 * 7 * 2 = do not install package releases that are not at least 2 weeks old
+# DO NOT REMOVE OR MODIFY minimumReleaseAge without approval
+# list packages to be excluded from minimum release limitation
+
 packages:
   - extras/*
   - packages/*


### PR DESCRIPTION
## Summary by Sourcery

Enforce safer fee options handling in the wallet and relayer while tightening dependency and release management across the monorepo.

Bug Fixes:
- Correct fee options execution by replacing the hard-coded fee options stub with a topology-aware stub signature in wallet fee option transactions.
- Align services, wallet, and ABI packages (3.0.7 → 3.0.9) to incorporate relayer fee options handling fixes across the stack.

Enhancements:
- Add a helper to derive a canonical stub signature from the wallet configuration topology for fee options transactions.
- Enforce a minimum package release age in the pnpm workspace to avoid installing overly new package versions.
- Update Next.js dependencies for docs and web apps and bump the pnpm package manager version used by the repo.

Tests:
- Update wallet fee options tests to assert against the new canonical stub signature used in execute calls.

Chores:
- Bump versions and changelogs for multiple packages to 3.0.9, reflecting fee options-related fixes and dependency updates.
- Refresh the pnpm lockfile to match the updated dependency graph.