### PR TITLE
Wallets.completeRedirect with metadata

### DIFF
--- a/packages/services/api/CHANGELOG.md
+++ b/packages/services/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/api
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/api",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "api sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/api",
   "author": "Sequence Platforms ULC",

--- a/packages/services/builder/CHANGELOG.md
+++ b/packages/services/builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/builder
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/builder/package.json
+++ b/packages/services/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/builder",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "builder sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/builder",
   "author": "Sequence Platforms ULC",

--- a/packages/services/guard/CHANGELOG.md
+++ b/packages/services/guard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/guard
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/guard/package.json
+++ b/packages/services/guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/guard",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "guard sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/guard",
   "author": "Sequence Platforms ULC",

--- a/packages/services/identity-instrument/CHANGELOG.md
+++ b/packages/services/identity-instrument/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/identity-instrument
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/identity-instrument/package.json
+++ b/packages/services/identity-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/identity-instrument",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/services/indexer/CHANGELOG.md
+++ b/packages/services/indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/indexer
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/indexer/package.json
+++ b/packages/services/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/indexer",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "indexer sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/indexer",
   "author": "Sequence Platforms ULC",

--- a/packages/services/marketplace/CHANGELOG.md
+++ b/packages/services/marketplace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/marketplace
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/marketplace/package.json
+++ b/packages/services/marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/marketplace",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "marketplace sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/marketplace",
   "author": "Sequence Platforms ULC",

--- a/packages/services/metadata/CHANGELOG.md
+++ b/packages/services/metadata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/metadata
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/metadata/package.json
+++ b/packages/services/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/metadata",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/services/relayer/CHANGELOG.md
+++ b/packages/services/relayer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @0xsequence/relayer
 
+## 3.1.1
+
+### Patch Changes
+
+- WDK fix
+- Updated dependencies
+  - @0xsequence/wallet-primitives@3.0.12
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/services/relayer/package.json
+++ b/packages/services/relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/relayer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/services/userdata/CHANGELOG.md
+++ b/packages/services/userdata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/userdata
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/services/userdata/package.json
+++ b/packages/services/userdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/userdata",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "userdata sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/services/userdata",
   "author": "Sequence Platforms ULC",

--- a/packages/utils/abi/CHANGELOG.md
+++ b/packages/utils/abi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/abi
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/utils/abi/package.json
+++ b/packages/utils/abi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/abi",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "abi sub-package for Sequence",
   "repository": "https://github.com/0xsequence/sequence.js/tree/master/packages/utils/abi",
   "author": "Sequence Platforms ULC",

--- a/packages/wallet/core/CHANGELOG.md
+++ b/packages/wallet/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @0xsequence/wallet-core
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+- Updated dependencies
+  - @0xsequence/guard@3.0.12
+  - @0xsequence/relayer@3.1.1
+  - @0xsequence/wallet-primitives@3.0.12
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/wallet/core/package.json
+++ b/packages/wallet/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-core",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/dapp-client/CHANGELOG.md
+++ b/packages/wallet/dapp-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @0xsequence/dapp-client
 
+## 3.1.1
+
+### Patch Changes
+
+- WDK fix
+- Updated dependencies
+  - @0xsequence/guard@3.0.12
+  - @0xsequence/relayer@3.1.1
+  - @0xsequence/wallet-core@3.0.12
+  - @0xsequence/wallet-primitives@3.0.12
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/wallet/dapp-client/package.json
+++ b/packages/wallet/dapp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/dapp-client",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/primitives/CHANGELOG.md
+++ b/packages/wallet/primitives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @0xsequence/wallet-primitives
 
+## 3.0.12
+
+### Patch Changes
+
+- WDK fix
+
 ## 3.0.11
 
 ### Patch Changes

--- a/packages/wallet/primitives/package.json
+++ b/packages/wallet/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-primitives",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/wdk/CHANGELOG.md
+++ b/packages/wallet/wdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @0xsequence/wallet-wdk
 
+## 3.1.1
+
+### Patch Changes
+
+- WDK fix
+- Updated dependencies
+  - @0xsequence/guard@3.0.12
+  - @0xsequence/identity-instrument@3.0.12
+  - @0xsequence/relayer@3.1.1
+  - @0xsequence/wallet-core@3.0.12
+  - @0xsequence/wallet-primitives@3.0.12
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/wallet/wdk/package.json
+++ b/packages/wallet/wdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/wallet-wdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet/wdk/src/sequence/index.ts
+++ b/packages/wallet/wdk/src/sequence/index.ts
@@ -15,6 +15,8 @@ export type {
   MnemonicSignupArgs,
   EmailOtpSignupArgs,
   CompleteRedirectArgs,
+  CompleteRedirectWithMetadataArgs,
+  CompleteRedirectMetadataResult,
   SignupArgs,
   AddLoginSignerArgs,
   RemoveLoginSignerArgs,

--- a/packages/wallet/wdk/src/sequence/wallets.ts
+++ b/packages/wallet/wdk/src/sequence/wallets.ts
@@ -101,6 +101,23 @@ export type IdTokenSignupArgs = CommonSignupArgs & {
 export type CompleteRedirectArgs = CommonSignupArgs & {
   state: string
   code: string
+  includeMetadata?: false
+}
+
+export type CompleteRedirectWithMetadataArgs = Omit<CompleteRedirectArgs, 'includeMetadata'> & {
+  includeMetadata: true
+}
+
+export type CompleteRedirectMetadataResult = {
+  target: string
+  addedLoginSigner?: {
+    wallet: Address.Address
+    signer: {
+      address: Address.Address
+      kind: string
+      email?: string
+    }
+  }
 }
 
 export type AuthCodeSignupArgs = CommonSignupArgs & {
@@ -278,6 +295,7 @@ export interface WalletsInterface {
    * @param args The arguments containing the `state` and `code` from the redirect, along with original sign-up options.
    * @returns A promise that resolves to target path that should be redirected to.
    */
+  completeRedirect(args: CompleteRedirectWithMetadataArgs): Promise<CompleteRedirectMetadataResult>
   completeRedirect(args: CompleteRedirectArgs): Promise<string>
 
   /**
@@ -923,11 +941,17 @@ export class Wallets implements WalletsInterface {
     return handler.commitAuth(args.target, { type: 'add-signer', wallet: args.wallet })
   }
 
-  async completeRedirect(args: CompleteRedirectArgs): Promise<string> {
+  async completeRedirect(args: CompleteRedirectWithMetadataArgs): Promise<CompleteRedirectMetadataResult>
+  async completeRedirect(args: CompleteRedirectArgs): Promise<string>
+  async completeRedirect(
+    args: CompleteRedirectArgs | CompleteRedirectWithMetadataArgs,
+  ): Promise<string | CompleteRedirectMetadataResult> {
     const commitment = await this.shared.databases.authCommitments.get(args.state)
     if (!commitment) {
       throw new Error('invalid-state')
     }
+
+    let addedLoginSigner: CompleteRedirectMetadataResult['addedLoginSigner']
 
     switch (commitment.type) {
       case 'add-signer': {
@@ -949,13 +973,31 @@ export class Wallets implements WalletsInterface {
           throw new Error('wallet-not-ready')
         }
 
-        const [signer] = await handler.completeAuth(commitment, args.code)
+        const [signer, metadata] = await handler.completeAuth(commitment, args.code)
         const signerKind = getSignerKindForSignup(commitment.kind)
+        const signerAddress = await signer.address
 
         await this.addLoginSignerFromPrepared(walletAddress, {
           signer,
           extra: { signerKind },
         })
+
+        const addedSigner: {
+          address: Address.Address
+          kind: string
+          email?: string
+        } = {
+          address: signerAddress,
+          kind: signerKind,
+        }
+        if (metadata?.email !== undefined) {
+          addedSigner.email = metadata.email
+        }
+
+        addedLoginSigner = {
+          wallet: walletAddress,
+          signer: addedSigner,
+        }
         break
       }
 
@@ -989,6 +1031,16 @@ export class Wallets implements WalletsInterface {
 
     if (!commitment.target) {
       throw new Error('invalid-state')
+    }
+
+    if (args.includeMetadata) {
+      const result: CompleteRedirectMetadataResult = {
+        target: commitment.target,
+      }
+      if (addedLoginSigner) {
+        result.addedLoginSigner = addedLoginSigner
+      }
+      return result
     }
 
     return commitment.target

--- a/packages/wallet/wdk/test/wallets.test.ts
+++ b/packages/wallet/wdk/test/wallets.test.ts
@@ -163,6 +163,109 @@ describe('Wallets', () => {
     expect(commitAuthSpy).toHaveBeenCalledWith('/auth/return', { type: 'auth' })
   })
 
+  it('Should expose added login signer metadata from redirect when requested', async () => {
+    manager = newManager({
+      identity: {
+        google: {
+          enabled: true,
+          clientId: 'test-google-client-id',
+        },
+      },
+    })
+
+    const wallet = await manager.wallets.signUp({
+      mnemonic: Mnemonic.random(Mnemonic.english),
+      kind: 'mnemonic',
+      noGuard: true,
+    })
+    expect(wallet).toBeDefined()
+
+    const handler = (manager as any).shared.handlers.get(Kinds.LoginGoogle) as AuthCodePkceHandler
+    const addedSigner = MnemonicHandler.toSigner(Mnemonic.random(Mnemonic.english))
+    if (!addedSigner) {
+      throw new Error('Failed to create added login signer for test')
+    }
+
+    const completeAuthSpy = vi
+      .spyOn(handler, 'completeAuth')
+      .mockResolvedValue([addedSigner as unknown as IdentitySigner, { email: 'secondary-google-user@example.com' }])
+
+    const state = 'add-signer-state-with-metadata'
+    await (manager as any).shared.databases.authCommitments.set({
+      id: state,
+      kind: 'google-pkce',
+      metadata: {},
+      target: '/account/signers',
+      type: 'add-signer',
+      wallet: wallet!,
+    })
+
+    const result = await manager.wallets.completeRedirect({
+      state,
+      code: 'auth-code',
+      includeMetadata: true,
+    })
+
+    expect(completeAuthSpy).toHaveBeenCalledWith(expect.objectContaining({ id: state }), 'auth-code')
+    expect(result).toEqual({
+      target: '/account/signers',
+      addedLoginSigner: {
+        wallet,
+        signer: {
+          address: await addedSigner.address,
+          kind: Kinds.LoginGoogle,
+          email: 'secondary-google-user@example.com',
+        },
+      },
+    })
+  })
+
+  it('Should keep returning the redirect target string when metadata is not requested', async () => {
+    manager = newManager({
+      identity: {
+        google: {
+          enabled: true,
+          clientId: 'test-google-client-id',
+        },
+      },
+    })
+
+    const wallet = await manager.wallets.signUp({
+      mnemonic: Mnemonic.random(Mnemonic.english),
+      kind: 'mnemonic',
+      noGuard: true,
+    })
+    expect(wallet).toBeDefined()
+
+    const handler = (manager as any).shared.handlers.get(Kinds.LoginGoogle) as AuthCodePkceHandler
+    const addedSigner = MnemonicHandler.toSigner(Mnemonic.random(Mnemonic.english))
+    if (!addedSigner) {
+      throw new Error('Failed to create added login signer for test')
+    }
+
+    vi.spyOn(handler, 'completeAuth').mockResolvedValue([
+      addedSigner as unknown as IdentitySigner,
+      { email: 'secondary-google-user@example.com' },
+    ])
+
+    const state = 'add-signer-state-without-metadata'
+    await (manager as any).shared.databases.authCommitments.set({
+      id: state,
+      kind: 'google-pkce',
+      metadata: {},
+      target: '/account/signers',
+      type: 'add-signer',
+      wallet: wallet!,
+    })
+
+    const result = await manager.wallets.completeRedirect({
+      state,
+      code: 'auth-code',
+    })
+
+    expect(result).toBe('/account/signers')
+  })
+
   it('Should reject google-id-token signup when Google is configured for redirect auth', async () => {
     manager = newManager({
       identity: {


### PR DESCRIPTION
## Summary by Sourcery

Add optional metadata-aware wallet redirect completion and bump package versions for a WDK fix release.

New Features:
- Allow wallet redirect completion to return structured metadata, including added login signer details, when explicitly requested.

Bug Fixes:
- Ensure add-signer redirect flows can surface login signer metadata such as email instead of only returning a target path.

Build:
- Bump versions of wallet, services, and utility packages to the 3.0.12/3.1.1 patch releases referencing the WDK fix.

Tests:
- Add coverage for completeRedirect with and without metadata to validate backwards-compatible behavior.